### PR TITLE
Add LSF support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,5 +8,6 @@ include slivka/conf/*.json
 graft slivka/project_template
 include slivka/scheduler/runners/runner.sh.tpl
 include slivka/scheduler/runners/runner.bash.tpl
+include slivka/scheduler/runners/lsf-runner.bash.tpl
 
 global-exclude *.py[co]

--- a/slivka/scheduler/runners/__init__.py
+++ b/slivka/scheduler/runners/__init__.py
@@ -3,8 +3,9 @@ from .runner import Runner, Command, Job, RunnerID
 from .shell import ShellRunner
 from .slivka_queue import SlivkaQueueRunner
 from .slurm import SlurmRunner
+from .lsf import LSFRunner
 
 __all__ = (
     'Runner', 'GridEngineRunner', 'ShellRunner', 'SlivkaQueueRunner',
-    'SlurmRunner', 'RunnerID', 'Command', 'Job'
+    'SlurmRunner', 'RunnerID', 'Command', 'Job', 'LSFRunner'
 )

--- a/slivka/scheduler/runners/lsf-runner.bash.tpl
+++ b/slivka/scheduler/runners/lsf-runner.bash.tpl
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+touch started
+{cmd} >stdout
+echo $? > finished
+

--- a/slivka/scheduler/runners/lsf.py
+++ b/slivka/scheduler/runners/lsf.py
@@ -1,0 +1,124 @@
+import logging
+import os
+import pwd
+import re
+import shlex
+import subprocess
+from collections import defaultdict
+from datetime import datetime, timedelta
+from typing import Sequence
+
+from slivka import JobStatus
+from slivka.compat import resources
+from slivka.utils import ttl_cache
+from ._bash_lex import bash_quote
+from .grid_engine import _StatusLetterDict
+from .runner import Runner, Job, Command
+
+log = logging.getLogger("slivka.scheduler")
+
+_runner_bash_tpl = resources.read_text(__name__, "lsf-runner.bash.tpl")
+
+
+_status_letters = _StatusLetterDict({
+    'PEND': JobStatus.QUEUED,
+    'PROV': JobStatus.QUEUED,
+    'PSUSP': JobStatus.UNKNOWN,
+    'RUN': JobStatus.RUNNING,
+    'USUSP': JobStatus.UNKNOWN,
+    'SSUSP': JobStatus.UNKNOWN,
+    'DONE': JobStatus.COMPLETED,
+    'EXIT': JobStatus.ERROR,
+    'UNKWN': JobStatus.UNKNOWN,
+    'WAIT': JobStatus.QUEUED,
+    'ZOMBI': JobStatus.ERROR
+})
+
+@ttl_cache(ttl=5)
+def _job_stat():
+    stdout = subprocess.check_output(
+        ['bjobs', '-noheader', '-w'],
+        encoding='ascii'
+    )
+    return {
+        jid: _status_letters[letter]
+        for jid, letter in re.findall(r'^(\w+)\s+\w+\s+([A-Z]+)', stdout, re.MULTILINE)
+    }
+
+
+class LSFRunner(Runner):
+    finished_job_timestamp = defaultdict(datetime.now)
+
+    def __init__(self, *args, bsubargs=(), **kwargs):
+        super().__init__(*args, **kwargs)
+        if isinstance(bsubargs, str):
+            bsubargs = shlex.split(bsubargs)
+        self.bsub_args = bsubargs
+        self.env.update(
+            (env, os.getenv(env)) for env in os.environ
+            if env.startswith("LSF") or env.startswith("LSB")
+        )
+
+    def submit(self, command: Command) -> Job:
+        cmd = str.join(' ', map(bash_quote, command.args))
+        input_script = _runner_bash_tpl.format(cmd=cmd)
+        proc = subprocess.run(
+            # NB unlike other runners, the "stdout" file gets redirected by the job
+            # script because LSF normally writes a "job report" to stdout, and there
+            # isn't a general and reliable way to suppress this as far as I can tell
+            # (see also https://stackoverflow.com/questions/9038314/can-i-suppress-an-lsf-job-report-without-sending-mail)
+            # so the "-o" here *just* sends the job report to its own file.  In future
+            # we could possibly switch to "-o /dev/null" if we decide we don't want
+            # the job report at all.
+            ['bsub', '-o', 'stdout.lsf', '-e', 'stderr',
+             *self.bsub_args],
+            input=input_script,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=command.cwd,
+            env=self.env,
+            encoding='ascii'
+        )
+        proc.check_returncode()
+        match = re.match(r'^Job <(\d+)>', proc.stdout)
+        return Job(match.group(1), command.cwd)
+
+    def batch_submit(self, commands: Sequence[Command]) -> Sequence[Job]:
+        return list(map(self.submit, commands))
+
+    def check_status(self, job: Job) -> JobStatus:
+        return self.batch_check_status([job])[0]
+
+    def batch_check_status(self, jobs: Sequence[Job]) -> Sequence[JobStatus]:
+        statuses = _job_stat()
+        result = []
+        for job in jobs:
+            status = statuses.get(job.id)
+            if status is None or status == JobStatus.COMPLETED:
+                fn = os.path.join(job.cwd, 'finished')
+                try:
+                    with open(fn) as fp:
+                        return_code = int(fp.read())
+                    self.finished_job_timestamp.pop(job.id, None)
+                    status = (
+                        JobStatus.COMPLETED if return_code == 0 else
+                        JobStatus.ERROR if return_code == 127 else
+                        JobStatus.INTERRUPTED if return_code >= 128 else
+                        JobStatus.INTERRUPTED if return_code < 0 else
+                        JobStatus.FAILED
+                    )
+                except FileNotFoundError:
+                    ts = self.finished_job_timestamp[job.id]
+                    if datetime.now() - ts < timedelta(minutes=1):
+                        status = JobStatus.RUNNING
+                    else:
+                        del self.finished_job_timestamp[job.id]
+                        status = JobStatus.INTERRUPTED
+            result.append(status)
+        return result
+
+    def cancel(self, job: Job):
+        subprocess.run(['bkill', job.id])
+
+    def batch_cancel(self, jobs: Sequence[Job]):
+        subprocess.run(['bkill', *(job.id for job in jobs)])

--- a/slivka/scheduler/runners/lsf.py
+++ b/slivka/scheduler/runners/lsf.py
@@ -17,7 +17,7 @@ from .runner import Runner, Job, Command
 
 log = logging.getLogger("slivka.scheduler")
 
-_runner_bash_tpl = resources.read_text(__name__, "lsf-runner.bash.tpl")
+_runner_bash_tpl = resources.read_text(__package__, "lsf-runner.bash.tpl")
 
 
 _status_letters = _StatusLetterDict({

--- a/sphinx-docs/getting_started.rst
+++ b/sphinx-docs/getting_started.rst
@@ -534,6 +534,14 @@ arguments which should not be overridden.
 
 .. _Slurm: https://slurm.schedmd.com/
 
+An ``LSFRunner` uses an LSF_ workload manager to execute jobs.  It
+wraps commands in bash scripts and submits them to LSF using a
+:program:`bsub` command.  ``LSFRunner`` accepts a single ``bsubargs``
+parameter containing a list of arguments that will be appended to the
+:program:`bsub` command.
+
+.. _LSF: https://www.ibm.com/docs/en/spectrum-lsf/
+
 Selector
 ========
 

--- a/sphinx-docs/specification.rst
+++ b/sphinx-docs/specification.rst
@@ -665,7 +665,8 @@ properties:
   built-in runners or a path to the custom class implementing Runner
   interface. Creating custom runners will be covered in the advanced
   usage guide. Available Built-in runners are ``ShellRunner``,
-  ``SlivkaQueueRunner``, ``GridEngineRunner`` and ``SlurmRunner``.
+  ``SlivkaQueueRunner``, ``GridEngineRunner``, ``SlurmRunner``,
+  and ``LSFRunner``.
 
 :*parameters*:
   Extra parameters that will be passed to the runner's constructor
@@ -723,8 +724,26 @@ properties:
   .. versionadded:: 0.8.1b0
     Introduced Slurm runner
 
+- ``LSFRunner` uses the third-party `IBM Spectrum LSF`_ to run jobs
+  via the :program:`bsub` command.  This solution allows many jobs to
+  be run on large compute clusters.  It requires LSF to be installed on
+  your system.
+
+  Parameters:
+
+  :*bsubargs*:
+    List of arguments appended to the :program:bsub: command that control
+    execution parameters.  The runner always provides ``-o`` and ``-e``
+    arguments, which should not be overridden.  The arguments can be 
+    provided as an array of strings or as a string, in which case they
+    will be split with :py:func:`shelx.split`.
+
+  .. versionadded:: 0.8.3b0
+    Introduced LSF runner
+
 .. _`Altair Grid Engine`: https://www.altair.com/grid-engine
 .. _`Slurm Workload Manager`: https://slurm.schedmd.com/
+.. _`IBM Spectrum LSF`: https://www.ibm.com/docs/en/spectrum-lsf/
 
 Selector
 ========


### PR DESCRIPTION
As discussed elsewhere, this PR adds a extra runner for submitting jobs to LSF via `bsub`, in much the same style as the existing Slurm and  Grid Engine runners.